### PR TITLE
Fix wrong app name in logger.h

### DIFF
--- a/source/wiiu/logger.h
+++ b/source/wiiu/logger.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 #define LOG_APP_TYPE "P"
-#define LOG_APP_NAME "homebrew_on_menu"
+#define LOG_APP_NAME "ftpiiu_plugin"
 
 #define __FILENAME_X__ (strrchr (__FILE__, '\\') ? strrchr (__FILE__, '\\') + 1 : __FILE__)
 #define __FILENAME__ (strrchr (__FILE__, '/') ? strrchr (__FILE__, '/') + 1 : __FILENAME_X__)


### PR DESCRIPTION
For logging purposes (i.e. when errors are logged in this plugin), LOG_APP_NAME inadvertently had the same name as the homebrew_on_menu plugin. This PR changes the app name to ftpiiu_plugin.